### PR TITLE
Add miss export in annotator-context

### DIFF
--- a/src/elements/common/annotator-context/index.ts
+++ b/src/elements/common/annotator-context/index.ts
@@ -1,4 +1,6 @@
 export { default as AnnotatorContext } from './AnnotatorContext';
+export { WithAnnotationsProps } from './withAnnotations';
 export { default as withAnnotations } from './withAnnotations';
+export { WithAnnotatorContextProps } from './withAnnotatorContext';
 export { default as withAnnotatorContext } from './withAnnotatorContext';
 export * from './types';


### PR DESCRIPTION
Add `WithAnnotationsProps` and `WithAnnotatorContextProps` to export statement to remove error:

- No matching export in "node_modules/box-ui-elements/es/elements/common/annotator-context/index.js" for import "WithAnnotatorContextProps"
- No matching export in "node_modules/box-ui-elements/es/elements/common/annotator-context/index.js" for import "WithAnnotationsProps"
- No matching export in "node_modules/box-ui-elements/es/elements/common/annotator-context/index.js" for import "WithAnnotatorContextProps"

this PR also effect https://github.com/Finitive-LLC/Finitive-Platform/pull/199 to solve error because of this

Now it success run, tested by "Yalc":

<img width="1680" alt="Screen Shot 2022-08-09 at 23 43 07" src="https://user-images.githubusercontent.com/26898125/183709285-94dbd728-05df-4ff4-8db8-b07ba8716485.png">

