### PR TITLE
Change API for recents

### DIFF
--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -19,8 +19,17 @@ import {
     SORT_DESC,
     ERROR_CODE_SEARCH,
 } from '../constants';
+
 import type { RequestOptions, ElementsErrorCallback } from '../common/types/api';
-import type { FlattenedBoxItem, FlattenedBoxItemCollection, Collection, BoxItemCollection } from '../common/types/core';
+import type {
+    FlattenedBoxItem,
+    FlattenedBoxItemCollection,
+    Collection,
+    BoxItemCollection,
+    SortBy,
+    SortDirection,
+    ItemType,
+} from '../common/types/core';
 import type APICache from '../utils/Cache';
 
 class Search extends Base {
@@ -48,6 +57,21 @@ class Search extends Base {
      * @property {string}
      */
     query: string;
+
+    /**
+     * @property {string}
+     */
+    sortBy: SortBy;
+
+    /**
+     * @property {string}
+     */
+    sortDirection: SortDirection;
+
+    /**
+     * @property {string}
+     */
+    type: ItemType;
 
     /**
      * @property {Function}
@@ -205,6 +229,7 @@ class Search extends Base {
         const requestFields = fields || FOLDER_FIELDS_TO_FETCH;
 
         this.errorCode = ERROR_CODE_SEARCH;
+
         return this.xhr
             .get({
                 url: this.getUrl(),
@@ -214,6 +239,9 @@ class Search extends Base {
                     ancestor_folder_ids: this.id,
                     limit: this.limit,
                     fields: requestFields.toString(),
+                    sort: this.sortBy || undefined,
+                    sortDirection: this.sortDirection || undefined,
+                    type: this.type || undefined,
                 },
                 headers: requestFields.includes(FIELD_REPRESENTATIONS)
                     ? {
@@ -262,6 +290,18 @@ class Search extends Base {
         // Clear the cache if needed
         if (options.forceFetch) {
             this.getCache().unset(this.key);
+        }
+
+        if (options.sortBy) {
+            this.sortBy = options.sortBy;
+        }
+
+        if (options.sortDirection) {
+            this.sortDirection = options.sortDirection;
+        }
+
+        if (options.type) {
+            this.type = options.type;
         }
 
         // Return the Cache value if it exists

--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -62,6 +62,8 @@ import {
     ERROR_CODE_ITEM_NAME_INVALID,
     ERROR_CODE_ITEM_NAME_TOO_LONG,
     TYPED_ID_FOLDER_PREFIX,
+    SORT_DESC,
+    FIELD_MODIFIED_AT,
 } from '../../constants';
 import type { ViewMode } from '../common/flowTypes';
 import type { MetadataQuery, FieldsToShow } from '../../common/types/metadataQueries';
@@ -83,6 +85,7 @@ import '../common/fonts.scss';
 import '../common/base.scss';
 import '../common/modal.scss';
 import './ContentExplorer.scss';
+import { ITEM_TYPE_FILE } from '../../common/constants';
 
 const GRID_VIEW_MAX_COLUMNS = 7;
 const GRID_VIEW_MIN_COLUMNS = 1;
@@ -736,14 +739,32 @@ class ContentExplorer extends Component<Props, State> {
             currentOffset: 0,
         });
 
-        // Fetch the folder using folder API
-        this.api.getRecentsAPI().recents(
+        this.api.getSearchAPI().search(
             rootFolderId,
+            'NOT %$!@%!@#!', // We can't use empty string to search all, so use "NOT" to act like search all
+            25,
+            0,
             (collection: Collection) => {
                 this.recentsSuccessCallback(collection, triggerNavigationEvent);
             },
-            this.errorCallback,
-            { fields: CONTENT_EXPLORER_FOLDER_FIELDS_TO_FETCH, forceFetch: true },
+            () => {
+                this.recentsSuccessCallback(
+                    {
+                        items: [],
+                        limit: 1,
+                        offset: 0,
+                        total_count: 0,
+                    },
+                    triggerNavigationEvent,
+                );
+            },
+            {
+                fields: CONTENT_EXPLORER_FOLDER_FIELDS_TO_FETCH,
+                forceFetch: true,
+                sortBy: FIELD_MODIFIED_AT,
+                sortDirection: SORT_DESC,
+                type: ITEM_TYPE_FILE,
+            },
         );
     }
 


### PR DESCRIPTION
Recents API

1. Change API recents to API search with default parameters
   - sort: modifiet_at
   - sortDirection: DESC
   - type: file (only show file)
   - query: NOT !@#!@@! (we cant use empty string to search all, so we use not random symbol)
2. Add some options in API search regarding type, sort, sortDirection

Now it success run, tested by "Yalc":
<img width="1680" alt="Screen Shot 2022-08-10 at 17 12 42" src="https://user-images.githubusercontent.com/26898125/183878139-1d6092ba-1445-42ec-9615-9db1f2ef715d.png">