### PR TITLE
Feature/fin 3654 download

### DIFF
--- a/src/elements/common/header/Header.js
+++ b/src/elements/common/header/Header.js
@@ -5,16 +5,14 @@
  */
 
 import React from 'react';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import Logo from './Logo';
 import messages from '../messages';
 import { VIEW_FOLDER, VIEW_RECENTS, VIEW_SEARCH } from '../../../constants';
 import type { View } from '../../../common/types/core';
 
 import './Header.scss';
-import Button from '../../../components/button';
 import Add from '../sub-header/Add';
-import IconDownload from '../../../icons/general/IconDownload';
 import IconSearch from '../../../icons/general/IconSearch';
 
 type Props = {
@@ -44,8 +42,6 @@ const Header = ({
     onSearch,
     logoUrl,
     intl,
-    isDownloadAllVisible,
-    onDownloadAll,
     onCreate,
     onUpload,
 }: Props) => {
@@ -71,12 +67,6 @@ const Header = ({
                     value={searchQuery}
                 />
             </div>
-            {isDownloadAllVisible && (
-                <Button onClick={onDownloadAll} type="button" className="outlined-button download-all">
-                    <IconDownload color="#013c4d" />
-                    <FormattedMessage {...messages.downloadAll} />
-                </Button>
-            )}
             {showAdd && (
                 <Add
                     isDisabled={!isFolder}

--- a/src/elements/common/sub-header/SubHeader.js
+++ b/src/elements/common/sub-header/SubHeader.js
@@ -21,9 +21,11 @@ type Props = {
     gridColumnCount?: number,
     gridMaxColumns?: number,
     gridMinColumns?: number,
+    isDownloadAllVisible: boolean,
     isSmall: boolean,
     maxGridColumnCountForWidth?: number,
     onCreate: Function,
+    onDownloadAll: Function,
     onGridViewSliderChange?: (newSliderValue: number) => void,
     onItemClick: Function,
     onSortChange: Function,
@@ -31,6 +33,7 @@ type Props = {
     onViewModeChange?: (viewMode: ViewMode) => void,
     rootId: string,
     rootName?: string,
+
     view: View,
     viewMode?: ViewMode,
 };
@@ -54,6 +57,8 @@ const SubHeader = ({
     rootName,
     view,
     viewMode = VIEW_MODE_LIST,
+    isDownloadAllVisible,
+    onDownloadAll,
 }: Props) => (
     <div className="be-sub-header" data-testid="be-sub-header">
         <SubHeaderLeft
@@ -79,6 +84,8 @@ const SubHeader = ({
             onViewModeChange={onViewModeChange}
             view={view}
             viewMode={viewMode}
+            isDownloadAllVisible={isDownloadAllVisible}
+            onDownloadAll={onDownloadAll}
         />
     </div>
 );

--- a/src/elements/common/sub-header/SubHeaderRight.js
+++ b/src/elements/common/sub-header/SubHeaderRight.js
@@ -12,6 +12,9 @@ import { VIEW_FOLDER, VIEW_MODE_GRID } from '../../../constants';
 import type { ViewMode } from '../flowTypes';
 import type { View, Collection } from '../../../common/types/core';
 import './SubHeaderRight.scss';
+import Button from '../../../components/button';
+import Tooltip from '../Tooltip';
+import IconDownloadSolid from '../../../icons/general/IconDownloadSolid';
 
 type Props = {
     canCreateNewFolder: boolean,
@@ -20,8 +23,10 @@ type Props = {
     gridColumnCount: number,
     gridMaxColumns: number,
     gridMinColumns: number,
+    isDownloadAllVisible: boolean,
     maxGridColumnCountForWidth: number,
     onCreate: Function,
+    onDownloadAll: Function,
     onGridViewSliderChange: (newSliderValue: number) => void,
     onSortChange: Function,
     onUpload: Function,
@@ -41,6 +46,8 @@ const SubHeaderRight = ({
     onViewModeChange,
     view,
     viewMode,
+    isDownloadAllVisible,
+    onDownloadAll,
 }: Props) => {
     const { sortBy, sortDirection, items = [] }: Collection = currentCollection;
     const hasGridView: boolean = !!gridColumnCount;
@@ -49,6 +56,18 @@ const SubHeaderRight = ({
     const showSort: boolean = isFolder && hasItems;
     return (
         <div className="be-sub-header-right">
+            {isDownloadAllVisible && (
+                <Tooltip text="Download all">
+                    <Button
+                        aria-label="Download All"
+                        onClick={onDownloadAll}
+                        type="button"
+                        className="btn bdl-ViewModeChangeButton"
+                    >
+                        <IconDownloadSolid width={17} height={17} fillColor="#909090" color="#909090" />
+                    </Button>
+                </Tooltip>
+            )}
             {hasItems && viewMode === VIEW_MODE_GRID && (
                 <GridViewSlider
                     columnCount={gridColumnCount}

--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -1717,7 +1717,7 @@ class ContentExplorer extends Component<Props, State> {
         const allowCreate: boolean = canCreateNewFolder && !!can_upload;
         const isDefaultViewMetadata: boolean = defaultView === DEFAULT_VIEW_METADATA;
         const isErrorView: boolean = view === VIEW_ERROR;
-        const isDownloadAllVisible: boolean = canDownload && defaultView !== VIEW_RECENTS;
+        const isDownloadAllVisible: boolean = canDownload;
 
         const viewMode = this.getViewMode();
         const maxGridColumnCount = this.getMaxNumberOfGridViewColumnsForWidth();
@@ -1766,6 +1766,8 @@ class ContentExplorer extends Component<Props, State> {
                                     onItemClick={this.fetchFolder}
                                     onSortChange={this.sort}
                                     onViewModeChange={this.changeViewMode}
+                                    isDownloadAllVisible={isDownloadAllVisible}
+                                    onDownloadAll={this.onDownloadAll}
                                 />
                             </>
                         )}

--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -140,26 +140,26 @@ button svg {
 
 .btn-primary {
     color: $white;
-    background-color: $primary-color;
-    border-color: $primary-color;
+    background-color: $fin-blues;
+    border-color: $fin-blues;
     -webkit-font-smoothing: antialiased;
 
     &:not(.bdl-is-disabled),
     &:not(.is-disabled) {
         &:focus {
-            background-color: lighten($primary-color, 8%);
-            border: 1px solid $primary-color;
+            background-color: lighten($fin-blues, 8%);
+            border: 1px solid $fin-blues;
             box-shadow: inset 0 0 0 1px fade-out($white, 0.2), 0 1px 2px fade-out($black, 0.9);
         }
 
         &:hover {
-            background-color: lighten($primary-color, 8%);
-            border-color: lighten($primary-color, 8%);
+            background-color: lighten($fin-blues, 8%);
+            border-color: lighten($fin-blues, 8%);
         }
 
         &:active {
-            background-color: darken($primary-color, 8%);
-            border-color: darken($primary-color, 8%);
+            background-color: darken($fin-blues, 8%);
+            border-color: darken($fin-blues, 8%);
             box-shadow: none;
         }
     }

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -4,6 +4,7 @@
 $white: #fff !default;
 $black: #000 !default;
 $countBadgeBackground: #e9163c !default;
+$fin-blues: #013c4d !default;
 
 // Box/Primary Blues
 $bdl-box-blue: #0061d5 !default;

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -5,6 +5,7 @@
 export const white = "#fff"; // white
 export const black = "#000"; // black
 export const countBadgeBackground = "#e9163c"; // countBadgeBackground
+export const finBlues = "#013c4d"; // fin-blues
 export const bdlBoxBlue = "#0061d5"; // bdl-box-blue
 export const bdlBoxBlue80 = "#3381dd"; // bdl-box-blue-80
 export const bdlBoxBlue50 = "#7fb0ea"; // bdl-box-blue-50

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -2,6 +2,7 @@
     "white": "#fff",
     "black": "#000",
     "countBadgeBackground": "#e9163c",
+    "fin-blues": "#013c4d",
     "bdl-box-blue": "#0061d5",
     "bdl-box-blue-80": "#3381dd",
     "bdl-box-blue-50": "#7fb0ea",

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -2,6 +2,7 @@
 export const white = '#fff'; // white
 export const black = '#000'; // black
 export const countBadgeBackground = '#e9163c'; // countBadgeBackground
+export const finBlues = '#013c4d'; // fin-blues
 export const bdlBoxBlue = '#0061d5'; // bdl-box-blue
 export const bdlBoxBlue80 = '#3381dd'; // bdl-box-blue-80
 export const bdlBoxBlue50 = '#7fb0ea'; // bdl-box-blue-50


### PR DESCRIPTION
Tickes:
https://finitiveplatform.atlassian.net/browse/FIN-3654
https://finitiveplatform.atlassian.net/browse/FIN-3652

Changes:
- Add css variable $fin-blues
- Move download all from header to sub header
- Show download all for recents mode
- Change download icon from outline to fill and remove the text download all

Screenshots:
On Upload
<img width="1680" alt="Screen Shot 2023-01-26 at 13 40 16" src="https://user-images.githubusercontent.com/26898125/214779767-3e043b0d-3d9f-492e-9db6-1e3557333416.png">

On Transaction Page
![Screen Shot 2023-01-26 at 14 10 40](https://user-images.githubusercontent.com/26898125/214779770-a7e9869b-2b25-477e-aa37-cf8cd1fdc426.png)

On BSS Page
<img width="1680" alt="Screen Shot 2023-01-26 at 13 39 20 (1)" src="https://user-images.githubusercontent.com/26898125/214779773-311e741c-cba5-469e-8361-cf388979d7c5.png">
